### PR TITLE
Change routes setup to not happen in 'require'

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rails_drivers (0.2.0)
+    rails_drivers (0.3.0)
       rails (~> 5.2)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ Add this line to your routes.rb:
 
 ```ruby
 require 'rails_drivers/routes'
+
+# This can go before or after your application's route definitions
+RailsDrivers::Routes.load_driver_routes
 ```
 
 ### RSpec

--- a/lib/rails_drivers/routes.rb
+++ b/lib/rails_drivers/routes.rb
@@ -11,6 +11,3 @@ module RailsDrivers
     end
   end
 end
-
-# This is meant to be executed as soon as the file is required
-RailsDrivers::Routes.load_driver_routes

--- a/lib/rails_drivers/version.rb
+++ b/lib/rails_drivers/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RailsDrivers
-  VERSION = '0.2.0'
+  VERSION = '0.3.0'
 end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -2,6 +2,8 @@
 
 require 'rails_drivers/routes'
 
+RailsDrivers::Routes.load_driver_routes
+
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   root to: 'home#index'


### PR DESCRIPTION
Rails's eager class loading ends up 'require'ing every single file in
every gem, so we can't rely on the lib/rails_drivers/routes.rb not being
required in the app's routes.rb.