### PR TITLE
Add rake tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ Just run `rails g driver my_new_driver_name`.
 The `driver` utility technically works with other generators and rake tasks, but is only guaranteed to work with migrations.
 The reason is that some generators assume a particular path, rather than using the Rails path methods.
 
-### Creating rake tasks for a driver
+### Creating a rake tasks for a driver
 
-Every driver includes a `lib/tasks` directory where you can define rake tasks. Rake tasks defined in drivers are automatically loaded and namespaced under `driver:driver_name:<namespace>:<task_name>`.
+Every driver includes a `lib/tasks` directory where you can define rake tasks. Rake tasks defined in drivers are automatically loaded and namespaced under `driver:<driver_name>:<namespace>:<task_name>`. For example,
 
 ### Testing for coupling
 

--- a/README.md
+++ b/README.md
@@ -34,9 +34,20 @@ Just run `rails g driver my_new_driver_name`.
 The `driver` utility technically works with other generators and rake tasks, but is only guaranteed to work with migrations.
 The reason is that some generators assume a particular path, rather than using the Rails path methods.
 
-### Creating a rake tasks for a driver
+### Creating a rake task in a driver
 
-Every driver includes a `lib/tasks` directory where you can define rake tasks. Rake tasks defined in drivers are automatically loaded and namespaced under `driver:<driver_name>:<namespace>:<task_name>`. For example,
+Every driver includes a `lib/tasks` directory where you can define rake tasks. Rake tasks defined in drivers are automatically loaded and namespaced.
+For example,
+
+```ruby
+# drivers/my_driver/lib/tasks/my_namespace.rake
+namespace :my_namespace do
+  task :task_name do
+  end
+end
+```
+
+Can be executed using `rake driver:my_driver:my_namespace:task_name`.
 
 ### Testing for coupling
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ Just run `rails g driver my_new_driver_name`.
 The `driver` utility technically works with other generators and rake tasks, but is only guaranteed to work with migrations.
 The reason is that some generators assume a particular path, rather than using the Rails path methods.
 
+### Creating rake tasks for a driver
+
+Every driver includes a `lib/tasks` directory where you can define rake tasks. Rake tasks defined in drivers are automatically loaded and namespaced under `driver:driver_name:<namespace>:<task_name>`.
+
 ### Testing for coupling
 
 Since drivers are merged into your main application just like engines, there's nothing stopping them from accessing other drivers, and there's nothing stopping your main application from accessing drivers. In order to ensure those things don't happen, we have a handful of rake tasks:

--- a/lib/generators/driver/driver_generator.rb
+++ b/lib/generators/driver/driver_generator.rb
@@ -9,7 +9,7 @@ class DriverGenerator < Rails::Generators::NamedBase
     create_file "drivers/#{file_name}/app/views/#{file_name}/.keep", ''
     create_file "drivers/#{file_name}/spec/.keep", ''
     create_file "drivers/#{file_name}/db/migrate/.keep", ''
-    create_file "drivers/#{file_name}/lib/.keep", ''
+    create_file "drivers/#{file_name}/lib/tasks/.keep", ''
 
     template 'routes.rb.erb',      "drivers/#{file_name}/config/routes.rb"
     template 'initializer.rb.erb', "drivers/#{file_name}/config/initializers/#{file_name}_feature.rb"

--- a/lib/rails_drivers/railtie.rb
+++ b/lib/rails_drivers/railtie.rb
@@ -7,7 +7,7 @@ module RailsDrivers
     rake_tasks do
       load File.expand_path("#{__dir__}/../tasks/rails_drivers_tasks.rake")
 
-      Dir['drivers/*/lib/tasks/**.rake'].each do |driver_rake_file|
+      Dir['drivers/*/lib/tasks/**/*.rake'].each do |driver_rake_file|
         load driver_rake_file
       end
     end

--- a/lib/rails_drivers/railtie.rb
+++ b/lib/rails_drivers/railtie.rb
@@ -6,6 +6,10 @@ module RailsDrivers
 
     rake_tasks do
       load File.expand_path("#{__dir__}/../tasks/rails_drivers_tasks.rake")
+
+      Dir['drivers/*/lib/tasks/**.rake'].each do |driver_rake_file|
+        load driver_rake_file
+      end
     end
 
     config.before_configuration { setup_paths }

--- a/lib/rails_drivers/railtie.rb
+++ b/lib/rails_drivers/railtie.rb
@@ -9,7 +9,13 @@ module RailsDrivers
 
       # load drivers rake tasks
       Dir['drivers/*/lib/tasks/**/*.rake'].each do |driver_rake_file|
-        load driver_rake_file
+        %r{^drivers/(?<driver_name>\w+)/} =~ driver_rake_file
+
+        namespace(:driver) do
+          namespace(driver_name) do
+            load driver_rake_file
+          end
+        end
       end
     end
 

--- a/lib/rails_drivers/railtie.rb
+++ b/lib/rails_drivers/railtie.rb
@@ -7,6 +7,7 @@ module RailsDrivers
     rake_tasks do
       load File.expand_path("#{__dir__}/../tasks/rails_drivers_tasks.rake")
 
+      # load drivers rake tasks
       Dir['drivers/*/lib/tasks/**/*.rake'].each do |driver_rake_file|
         load driver_rake_file
       end

--- a/lib/rails_drivers/version.rb
+++ b/lib/rails_drivers/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RailsDrivers
-  VERSION = '0.3.2'
+  VERSION = '0.4.0'
 end

--- a/spec/drivers_spec.rb
+++ b/spec/drivers_spec.rb
@@ -222,8 +222,8 @@ RSpec.describe 'A Rails Driver' do
     end
 
     it 'properly loads the rake tasks' do
-      run_command 'rake driver:store:dummy:run'
-      run_command 'rake driver:store:dummy_nested:run'
+      expect { run_command 'rake driver:store:dummy:run' }.to_not raise_error
+      expect { run_command 'rake driver:store:dummy_nested:run' }.to_not raise_error
     end
   end
 end

--- a/spec/drivers_spec.rb
+++ b/spec/drivers_spec.rb
@@ -222,8 +222,8 @@ RSpec.describe 'A Rails Driver' do
     end
 
     it 'properly loads the rake tasks' do
-      run_command 'rake dummy:run'
-      run_command 'rake dummy_nested:run'
+      run_command 'rake driver:store:dummy:run'
+      run_command 'rake driver:store:dummy_nested:run'
     end
   end
 end

--- a/spec/drivers_spec.rb
+++ b/spec/drivers_spec.rb
@@ -203,4 +203,38 @@ RSpec.describe 'A Rails Driver' do
       run_command 'rspec drivers/store/spec/models/product_spec.rb -t not_in_driver'
     end
   end
+
+  context 'with a rake task in a driver' do
+    let(:rake_file) do
+      <<-RUBY
+        namespace :dummy do
+          desc 'A dummy rake task'
+          task :run do
+            # Do absolutely nothing!
+          end
+        end
+      RUBY
+    end
+
+    let(:rake_file_nested) do
+      <<-RUBY
+        namespace :dummy_nested do
+          desc 'A dummy rake task'
+          task :run do
+            # Do absolutely nothing!
+          end
+        end
+      RUBY
+    end
+
+    before do
+      create_file 'drivers/store/lib/tasks/dummy.rake', rake_file
+      create_file 'drivers/store/lib/tasks/nested/dummy.rake', rake_file_nested
+    end
+
+    it 'properly loads the rake tasks' do
+      run_command 'rake dummy:run'
+      run_command 'rake dummy_nested:run'
+    end
+  end
 end

--- a/spec/drivers_spec.rb
+++ b/spec/drivers_spec.rb
@@ -205,20 +205,9 @@ RSpec.describe 'A Rails Driver' do
   end
 
   context 'with a rake task in a driver' do
-    let(:rake_file) do
+    def make_rake_task(namespace)
       <<-RUBY
-        namespace :dummy do
-          desc 'A dummy rake task'
-          task :run do
-            # Do absolutely nothing!
-          end
-        end
-      RUBY
-    end
-
-    let(:rake_file_nested) do
-      <<-RUBY
-        namespace :dummy_nested do
+        namespace :#{namespace} do
           desc 'A dummy rake task'
           task :run do
             # Do absolutely nothing!
@@ -228,8 +217,8 @@ RSpec.describe 'A Rails Driver' do
     end
 
     before do
-      create_file 'drivers/store/lib/tasks/dummy.rake', rake_file
-      create_file 'drivers/store/lib/tasks/nested/dummy.rake', rake_file_nested
+      create_file 'drivers/store/lib/tasks/dummy.rake', make_rake_task(:dummy)
+      create_file 'drivers/store/lib/tasks/nested/dummy.rake', make_rake_task(:dummy_nested)
     end
 
     it 'properly loads the rake tasks' do

--- a/spec/generators/driver_generator_spec.rb
+++ b/spec/generators/driver_generator_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe 'rails g driver' do
     expect(dummy_app).to have_file 'drivers/driver_name/app/views/driver_name/'
     expect(dummy_app).to have_file 'drivers/driver_name/config/routes.rb'
     expect(dummy_app).to have_file 'drivers/driver_name/config/initializers/driver_name_feature.rb'
+    expect(dummy_app).to have_file 'drivers/driver_name/lib/tasks/.keep'
   end
 
   context 'the namespace' do


### PR DESCRIPTION
## Context

I noticed rails_drivers does not load rake files for drivers. This pull request loads rake task files from a driver.

Unfortunately, I was unable to load Rake tasks inside the driver initializers folder since these hooks are loaded before booting up Rails and not Rake.