### PR TITLE
Introduce "overrides" system

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,6 +18,11 @@ Style/NestedParenthesizedCalls:
   Exclude:
     - spec/**/*
 
+Style/ClassVars:
+  Exclude:
+    # rubocop doesn't seem to know what's going on here.
+    - lib/rails_drivers/overrides.rb
+
 Metrics/BlockLength:
   Exclude:
     - spec/**/*

--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gemspec
 
 group :development, :test do
   gem 'factory_bot_rails', require: false
+  gem 'irb'
   gem 'pry-byebug'
   gem 'rubocop'
-  gem 'irb'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rails_drivers (0.3.2)
+    rails_drivers (0.5.0)
       rails (~> 5.2)
 
 GEM
@@ -194,4 +194,4 @@ DEPENDENCIES
   webpacker (~> 3.5)
 
 BUNDLED WITH
-   2.0.2
+   2.1.4

--- a/README.md
+++ b/README.md
@@ -61,6 +61,36 @@ end
 
 Can be executed using `rake driver:my_driver:my_namespace:task_name`.
 
+### Overrides
+
+Sometimes you want to add a method to a core class, but that method will only be used by one driver. This can be achieved by adding files to your driver's `overrides` directory.
+
+```ruby
+# app/models/product.rb
+# (doesn't have to be a model - can be anything)
+class Product < ApplicationRecord
+  # When you include this, every driver's product_override.rb is loaded and
+  # included. Works correctly with autoloading during development.
+  include RailsDrivers::Overrides
+end
+
+
+# drivers/my_driver/overrides/product_override.rb
+module ProductOverride
+  extend ActiveSupport::Concern
+
+  def new_method
+    'Please only call me from code inside my_driver'
+  end
+end
+
+
+# Anywhere in my_driver (or elsewhere, but that's bad style)
+Product.new.new_method
+```
+
+For each Override, the accompanying class simply `includes` it, so any methods you define will be available throughout the whole app. To make sure your drivers don't change the core behavior of the app, see [Testing for coupling](#testing-for-coupling).
+
 ### Testing for coupling
 
 Since drivers are merged into your main application just like engines, there's nothing stopping them from accessing other drivers, and there's nothing stopping your main application from accessing drivers. In order to ensure those things don't happen, we have a handful of rake tasks:

--- a/README.md
+++ b/README.md
@@ -76,11 +76,13 @@ end
 
 
 # drivers/my_driver/overrides/product_override.rb
-module ProductOverride
-  extend ActiveSupport::Concern
+module MyDriver
+  module ProductOverride
+    extend ActiveSupport::Concern
 
-  def new_method
-    'Please only call me from code inside my_driver'
+    def new_method
+      'Please only call me from code inside my_driver'
+    end
   end
 end
 

--- a/lib/generators/driver/USAGE
+++ b/lib/generators/driver/USAGE
@@ -11,5 +11,6 @@ Example:
         drivers/new_feature/app/models/new_feature
         drivers/new_feature/app/views/new_feature
         drivers/new_feature/config
+        drivers/new_feature/overrides
         drivers/new_feature/spec
         drivers/new_feature/lib

--- a/lib/generators/driver/driver_generator.rb
+++ b/lib/generators/driver/driver_generator.rb
@@ -10,6 +10,7 @@ class DriverGenerator < Rails::Generators::NamedBase
     create_file "drivers/#{file_name}/spec/.keep", ''
     create_file "drivers/#{file_name}/db/migrate/.keep", ''
     create_file "drivers/#{file_name}/lib/tasks/.keep", ''
+    create_file "drivers/#{file_name}/overrides/.keep", ''
 
     template 'routes.rb.erb',      "drivers/#{file_name}/config/routes.rb"
     template 'initializer.rb.erb', "drivers/#{file_name}/config/initializers/#{file_name}_feature.rb"

--- a/lib/rails_drivers.rb
+++ b/lib/rails_drivers.rb
@@ -3,6 +3,7 @@
 require 'rails_drivers/version'
 require 'rails_drivers/setup'
 require 'rails_drivers/railtie'
+require 'rails_drivers/overrides'
 
 module RailsDrivers
   class << self

--- a/lib/rails_drivers/overrides.rb
+++ b/lib/rails_drivers/overrides.rb
@@ -4,6 +4,8 @@ module RailsDrivers
   module Overrides
     extend ActiveSupport::Concern
 
+    # Including this module results in all available override modules being
+    # included.
     included do
       cattr_reader :driver_overrides
 
@@ -16,11 +18,29 @@ module RailsDrivers
 
       @@driver_overrides = possible_overrides.map do |path|
         require_dependency path
+        %r{drivers/(?<driver_name>[^/]+)/overrides} =~ path
 
-        override = "#{name}Override".constantize
+        override = "#{driver_name.classify}::#{name}Override".constantize
         include override
         override
       end.freeze
+
+      singleton_class.prepend MethodAddedHook
+    end
+
+    # This module is prepended to the singleton class of the including class
+    # to detect when an override is attempting to re-define any methods.
+    module MethodAddedHook
+      def method_added(method_name)
+        driver_overrides.each do |override|
+          next unless override.instance_methods.include?(method_name)
+
+          Rails.logger.warn "Driver override method #{override.name}##{method_name} "\
+            "is shadowed by #{name}##{method_name} and will likely not do anything."
+        end
+
+        super(method_name)
+      end
     end
   end
 end

--- a/lib/rails_drivers/overrides.rb
+++ b/lib/rails_drivers/overrides.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module RailsDrivers
+  module Overrides
+    extend ActiveSupport::Concern
+
+    included do
+      possible_overrides = Dir.glob(
+        Rails.root.join(
+          'drivers', '*', 'overrides',
+          "#{name.underscore}_override.rb"
+        )
+      )
+
+      possible_overrides.each do |path|
+        require_dependency path
+
+        include "#{name}Override".constantize
+      end
+    end
+  end
+end

--- a/lib/rails_drivers/overrides.rb
+++ b/lib/rails_drivers/overrides.rb
@@ -25,12 +25,12 @@ module RailsDrivers
         override
       end.freeze
 
-      singleton_class.prepend MethodAddedHook
+      singleton_class.prepend CheckForShadowedMethods
     end
 
     # This module is prepended to the singleton class of the including class
     # to detect when an override is attempting to re-define any methods.
-    module MethodAddedHook
+    module CheckForShadowedMethods
       def method_added(method_name)
         driver_overrides.each do |override|
           next unless override.instance_methods.include?(method_name)

--- a/lib/rails_drivers/overrides.rb
+++ b/lib/rails_drivers/overrides.rb
@@ -5,6 +5,8 @@ module RailsDrivers
     extend ActiveSupport::Concern
 
     included do
+      cattr_reader :driver_overrides
+
       possible_overrides = Dir.glob(
         Rails.root.join(
           'drivers', '*', 'overrides',
@@ -12,11 +14,13 @@ module RailsDrivers
         )
       )
 
-      possible_overrides.each do |path|
+      @@driver_overrides = possible_overrides.map do |path|
         require_dependency path
 
-        include "#{name}Override".constantize
-      end
+        override = "#{name}Override".constantize
+        include override
+        override
+      end.freeze
     end
   end
 end

--- a/lib/rails_drivers/version.rb
+++ b/lib/rails_drivers/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RailsDrivers
-  VERSION = '0.4.0'
+  VERSION = '0.5.0'
 end

--- a/spec/overrides_spec.rb
+++ b/spec/overrides_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Rails Driver Overrides' do
+  let(:product_model) do
+    <<-RUBY
+      class Product
+        include RailsDrivers::Overrides
+
+        def say_hello
+          'hello'
+        end
+      end
+    RUBY
+  end
+
+  let(:product_override) do
+    <<-RUBY
+      module ProductOverride
+        extend ActiveSupport::Concern
+
+        def override_method
+          'it worked!'
+        end
+      end
+    RUBY
+  end
+
+  let(:alt_product_override) do
+    <<-RUBY
+      module ProductOverride
+        extend ActiveSupport::Concern
+
+        def override_method
+          'it worked! (v2)'
+        end
+      end
+    RUBY
+  end
+
+  before do
+    create_file 'app/models/product.rb', product_model
+  end
+
+  context 'with no override present' do
+    specify 'the model still functions' do
+      say_hello_result = run_ruby %(puts Product.new.say_hello)
+      expect(say_hello_result).to eq "hello\n"
+
+      override_method_included = run_ruby %(puts Product.new.respond_to?(:override_method))
+      expect(override_method_included).to eq "false\n"
+    end
+
+    specify 'an override can be added mid-session' do
+      create_file 'tmp/product_override.rb', product_override
+
+      script = %(
+        # First, confirm the product already exists
+        IO.write 'before.out', Product.new.respond_to?(:override_method)
+
+        # Write file mid-session
+        FileUtils.mkdir_p 'drivers/store/overrides'
+        FileUtils.cp 'tmp/product_override.rb', 'drivers/store/overrides'
+
+        # Reload and the plugin should show up
+        reload!
+        IO.write 'after.out', Product.new.override_method
+      )
+
+      run_command 'rails c', input: script
+
+      before = read_file('before.out')
+      after = read_file('after.out')
+
+      expect(before).to eq 'false'
+      expect(after).to eq 'it worked!'
+    end
+  end
+
+  context 'with an override present' do
+    before do
+      create_file 'drivers/store/overrides/product_override.rb', product_override
+    end
+
+    it 'is included by the model' do
+      override_method_exists = run_ruby %(puts Product.new.respond_to?(:override_method))
+      expect(override_method_exists).to eq "true\n"
+
+      override_method_output = run_ruby %(puts Product.new.override_method)
+      expect(override_method_output).to eq "it worked!\n"
+    end
+
+    it 'persists across reloads' do
+      create_file 'tmp/new_product_override.rb', alt_product_override
+
+      script = %(
+        IO.write 'before.out', Product.new.override_method
+        FileUtils.cp 'tmp/new_product_override.rb', 'drivers/store/overrides/product_override.rb'
+        reload!
+        IO.write 'after.out', Product.new.override_method
+      )
+
+      run_command 'rails c', input: script
+
+      before = read_file('before.out')
+      after = read_file('after.out')
+
+      expect(before).to eq 'it worked!'
+      expect(after).to eq 'it worked! (v2)'
+    end
+  end
+end

--- a/spec/overrides_spec.rb
+++ b/spec/overrides_spec.rb
@@ -91,6 +91,11 @@ RSpec.describe 'Rails Driver Overrides' do
       expect(override_method_output).to eq "it worked!\n"
     end
 
+    it "populates the model's driver_overrides" do
+      overrides = run_ruby %(puts Product.driver_overrides.to_s)
+      expect(overrides).to eq "[ProductOverride]\n"
+    end
+
     it 'persists across reloads' do
       create_file 'tmp/new_product_override.rb', alt_product_override
 

--- a/spec/support/dummy_app_helpers.rb
+++ b/spec/support/dummy_app_helpers.rb
@@ -20,23 +20,26 @@ module DummyAppHelpers
   # Running commands
   #
 
-  def wait_for_command(stdout, stderr, process)
+  def wait_for_command(cmd, stdout, stderr, process, capture_stderr = false)
     error = truncate_lines(stderr)
     std = truncate_lines(stdout)
     code = process.value
     raise "Exited with code #{code}: #{cmd}\n#{error.join}\n#{std.join}" if code != 0
 
-    std.join
+    result = []
+    result += error if capture_stderr
+    result += std
+    result.join
   end
 
-  def run_command(cmd, input: nil)
+  def run_command(cmd, input: nil, capture_stderr: false)
     raise 'No dummy app' if dummy_app.nil?
 
     stdin, stdout, stderr, process = Open3.popen3('sh', '-c', "bundle exec #{cmd}", chdir: dummy_app)
     stdin.write input if input
     stdin.close
 
-    wait_for_command(stdout, stderr, process)
+    wait_for_command(cmd, stdout, stderr, process, capture_stderr)
   ensure
     stdout&.close
     stderr&.close

--- a/spec/support/dummy_app_helpers.rb
+++ b/spec/support/dummy_app_helpers.rb
@@ -20,19 +20,23 @@ module DummyAppHelpers
   # Running commands
   #
 
-  def run_command(cmd, input: nil)
-    raise 'No dummy app' if dummy_app.nil?
-
-    stdin, stdout, stderr, wait = Open3.popen3('sh', '-c', "bundle exec #{cmd}", chdir: dummy_app)
-    stdin.write input if input
-    stdin.close
-
+  def wait_for_command(stdout, stderr, process)
     error = truncate_lines(stderr)
     std = truncate_lines(stdout)
-    code = wait.value
+    code = process.value
     raise "Exited with code #{code}: #{cmd}\n#{error.join}\n#{std.join}" if code != 0
 
     std.join
+  end
+
+  def run_command(cmd, input: nil)
+    raise 'No dummy app' if dummy_app.nil?
+
+    stdin, stdout, stderr, process = Open3.popen3('sh', '-c', "bundle exec #{cmd}", chdir: dummy_app)
+    stdin.write input if input
+    stdin.close
+
+    wait_for_command(stdout, stderr, process)
   ensure
     stdout&.close
     stderr&.close


### PR DESCRIPTION
Most of our non-trivial drivers end up wanting to make small additions to core classes (new associations to models, etc.)

This gives us a standard way to do that.

```ruby
# app/models/product.rb
# (doesn't have to be a model - can be anything)
class Product < ApplicationRecord
  # When you include this, every driver's product_override.rb is loaded and
  # included. Works correctly with autoloading during development.
  include RailsDrivers::Overrides
end

# drivers/my_driver/overrides/product_override.rb
module MyDriver::ProductOverride # Must be namespaced despite path
  extend ActiveSupport::Concern
  def new_method
    'Please only call me from code inside my_driver'
  end
end

# Anywhere in my_driver (or elsewhere, but that won't pass tests)
Product.new.new_method
```

It might seem a little gross, but we can still test for coupling so I don't think it really matters. If an override is being used by code outside the driver in question, it will be caught by the CI.