### PR TITLE
add README to generator

### DIFF
--- a/lib/generators/driver/driver_generator.rb
+++ b/lib/generators/driver/driver_generator.rb
@@ -19,6 +19,6 @@ class DriverGenerator < Rails::Generators::NamedBase
     template 'routes.rb.erb',      "drivers/#{file_name}/config/routes.rb"
     template 'initializer.rb.erb', "drivers/#{file_name}/config/initializers/#{file_name}_feature.rb"
     template 'module.rb.erb',      "drivers/#{file_name}/app/models/#{file_name}.rb"
-    template 'README.md', "drivers/#{file_name}/README.md"
+    template 'README.md.erb',      "drivers/#{file_name}/README.md"
   end
 end

--- a/lib/generators/driver/driver_generator.rb
+++ b/lib/generators/driver/driver_generator.rb
@@ -15,5 +15,6 @@ class DriverGenerator < Rails::Generators::NamedBase
     template 'routes.rb.erb',      "drivers/#{file_name}/config/routes.rb"
     template 'initializer.rb.erb', "drivers/#{file_name}/config/initializers/#{file_name}_feature.rb"
     template 'module.rb.erb',      "drivers/#{file_name}/app/models/#{file_name}.rb"
+    template 'README.md', "drivers/#{file_name}/README.md"
   end
 end

--- a/lib/generators/driver/driver_generator.rb
+++ b/lib/generators/driver/driver_generator.rb
@@ -12,6 +12,10 @@ class DriverGenerator < Rails::Generators::NamedBase
     create_file "drivers/#{file_name}/lib/tasks/.keep", ''
     create_file "drivers/#{file_name}/extensions/.keep", ''
 
+    create_templated_files
+  end
+
+  def create_templated_files
     template 'routes.rb.erb',      "drivers/#{file_name}/config/routes.rb"
     template 'initializer.rb.erb', "drivers/#{file_name}/config/initializers/#{file_name}_feature.rb"
     template 'module.rb.erb',      "drivers/#{file_name}/app/models/#{file_name}.rb"

--- a/lib/generators/driver/templates/README.md
+++ b/lib/generators/driver/templates/README.md
@@ -1,0 +1,3 @@
+## README
+
+This README file should be used to explain the functionality of the driver.

--- a/lib/generators/driver/templates/README.md.erb
+++ b/lib/generators/driver/templates/README.md.erb
@@ -1,3 +1,3 @@
-## README
+## <%= class_name %> README
 
 This README file should be used to explain the functionality of the driver.

--- a/lib/generators/driver/templates/initializer.rb.erb
+++ b/lib/generators/driver/templates/initializer.rb.erb
@@ -1,5 +1,5 @@
 # The core app (or other drivers) can check the presence of the
-# <%= class_name %> driver with the following code snippit
+# <%= class_name %> driver with the following code snippet
 #
 #   do_something if RailsDrivers.loaded.include(:<%= file_name %>)
 #

--- a/lib/rails_drivers/version.rb
+++ b/lib/rails_drivers/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RailsDrivers
-  VERSION = '1.0.0'
+  VERSION = '1.1.0'
 end

--- a/spec/generators/driver_generator_spec.rb
+++ b/spec/generators/driver_generator_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe 'rails g driver' do
     expect(dummy_app).to have_file 'drivers/driver_name/config/routes.rb'
     expect(dummy_app).to have_file 'drivers/driver_name/config/initializers/driver_name_feature.rb'
     expect(dummy_app).to have_file 'drivers/driver_name/lib/tasks/.keep'
+    expect(dummy_app).to have_file 'drivers/driver_name/README.md'
   end
 
   context 'the namespace' do

--- a/spec/generators/driver_generator_spec.rb
+++ b/spec/generators/driver_generator_spec.rb
@@ -7,18 +7,41 @@ RSpec.describe 'rails g driver' do
     run_command 'rails g driver driver_name'
   end
 
-  it 'creates the necessary files' do
-    expect(dummy_app).to have_file 'drivers/driver_name/app/'
-    expect(dummy_app).to have_file 'drivers/driver_name/app/models/driver_name/'
-    expect(dummy_app).to have_file 'drivers/driver_name/app/models/driver_name.rb'
-    expect(dummy_app).to have_file 'drivers/driver_name/app/controllers/'
-    expect(dummy_app).to have_file 'drivers/driver_name/app/controllers/driver_name/'
-    expect(dummy_app).to have_file 'drivers/driver_name/app/views/'
-    expect(dummy_app).to have_file 'drivers/driver_name/app/views/driver_name/'
-    expect(dummy_app).to have_file 'drivers/driver_name/config/routes.rb'
-    expect(dummy_app).to have_file 'drivers/driver_name/config/initializers/driver_name_feature.rb'
-    expect(dummy_app).to have_file 'drivers/driver_name/lib/tasks/.keep'
-    expect(dummy_app).to have_file 'drivers/driver_name/README.md'
+  context 'creating files' do
+    it 'creates the app directory' do
+      expect(dummy_app).to have_file 'drivers/driver_name/app/'
+    end
+
+    it 'creates the models directory' do
+      expect(dummy_app).to have_file 'drivers/driver_name/app/models/driver_name/'
+      expect(dummy_app).to have_file 'drivers/driver_name/app/models/driver_name.rb'
+    end
+
+    it 'creates the controllers directory' do
+      expect(dummy_app).to have_file 'drivers/driver_name/app/controllers/'
+      expect(dummy_app).to have_file 'drivers/driver_name/app/controllers/driver_name/'
+    end
+
+    it 'creates the views directory' do
+      expect(dummy_app).to have_file 'drivers/driver_name/app/views/'
+      expect(dummy_app).to have_file 'drivers/driver_name/app/views/driver_name/'
+    end
+
+    it 'creates the routes' do
+      expect(dummy_app).to have_file 'drivers/driver_name/config/routes.rb'
+    end
+
+    it 'creates the driver initializer' do
+      expect(dummy_app).to have_file 'drivers/driver_name/config/initializers/driver_name_feature.rb'
+    end
+
+    it 'creates the tasks directory' do
+      expect(dummy_app).to have_file 'drivers/driver_name/lib/tasks/.keep'
+    end
+
+    it 'creates the readme' do
+      expect(dummy_app).to have_file 'drivers/driver_name/README.md'
+    end
   end
 
   context 'the namespace' do

--- a/spec/generators/driver_generator_spec.rb
+++ b/spec/generators/driver_generator_spec.rb
@@ -61,4 +61,10 @@ RSpec.describe 'rails g driver' do
       expect(read_file('drivers/driver_name/config/routes.rb')).to include "Dummy::Application.routes.draw do\n"
     end
   end
+
+  context 'the readme' do
+    it 'includes the driver name' do
+      expect(read_file('drivers/driver_name/README.md')).to include 'DriverName'
+    end
+  end
 end


### PR DESCRIPTION
Drivers can often interact with core applications in ways that are not immediately obvious - the addition of a simple readme to describe driver functionality at first glance should be helpful.