### PR TITLE
Remove require from dummy application

### DIFF
--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -16,7 +16,6 @@ require 'sprockets/railtie'
 # require "rails/test_unit/railtie"
 
 Bundler.require(*Rails.groups)
-require 'rails_drivers'
 
 module Dummy
   class Application < Rails::Application


### PR DESCRIPTION
### Context

We are not exactly sure why this is required. Going to remove it from the dummy repo and see if tests still pass. 