### PR TITLE
Allow for the path drivers live in to be configurable

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,7 @@ jobs:
     strategy:
       matrix:
         rails: ['5.2', '6.0']
+        drivers_path: ['drivers', 'components']
     steps:
       - uses: actions/checkout@v1
       - name: Set up Ruby 2.5
@@ -43,4 +44,4 @@ jobs:
           gem install bundler
           bundle install --jobs 4 --retry 3
       - name: RSpec
-        run: RAILS_VERSION=${{ matrix.rails }} bundle exec rspec
+        run: RAILS_VERSION=${{ matrix.rails }} DRIVERS_PATH=${{ matrix.drivers_path }} bundle exec rspec

--- a/bin/driver
+++ b/bin/driver
@@ -29,7 +29,7 @@ else
 
   require_relative "#{Dir.pwd}/config/boot"
 
-  possible_drivers = Dir['drivers/*'].map { |d| d.split('/').last }
+  possible_drivers = Dir["#{RailsDrivers.config.drivers_path}/*"].map { |d| d.split('/').last }
   unless possible_drivers.include?(REPLACE_DEFAULT_PATH_WITH_DRIVER)
     puts "Unknown driver #{REPLACE_DEFAULT_PATH_WITH_DRIVER}. Must be one of [#{possible_drivers.join(', ')}]"
     exit 1

--- a/lib/generators/driver/driver_generator.rb
+++ b/lib/generators/driver/driver_generator.rb
@@ -4,21 +4,21 @@ class DriverGenerator < Rails::Generators::NamedBase
   source_root File.expand_path('templates', __dir__)
 
   def create_driver_dir_structure
-    create_file "drivers/#{file_name}/app/models/#{file_name}/.keep", ''
-    create_file "drivers/#{file_name}/app/controllers/#{file_name}/.keep", ''
-    create_file "drivers/#{file_name}/app/views/#{file_name}/.keep", ''
-    create_file "drivers/#{file_name}/spec/.keep", ''
-    create_file "drivers/#{file_name}/db/migrate/.keep", ''
-    create_file "drivers/#{file_name}/lib/tasks/.keep", ''
-    create_file "drivers/#{file_name}/extensions/.keep", ''
+    create_file "#{RailsDrivers.config.drivers_path}/#{file_name}/app/models/#{file_name}/.keep", ''
+    create_file "#{RailsDrivers.config.drivers_path}/#{file_name}/app/controllers/#{file_name}/.keep", ''
+    create_file "#{RailsDrivers.config.drivers_path}/#{file_name}/app/views/#{file_name}/.keep", ''
+    create_file "#{RailsDrivers.config.drivers_path}/#{file_name}/spec/.keep", ''
+    create_file "#{RailsDrivers.config.drivers_path}/#{file_name}/db/migrate/.keep", ''
+    create_file "#{RailsDrivers.config.drivers_path}/#{file_name}/lib/tasks/.keep", ''
+    create_file "#{RailsDrivers.config.drivers_path}/#{file_name}/extensions/.keep", ''
 
     create_templated_files
   end
 
   def create_templated_files
-    template 'routes.rb.erb',      "drivers/#{file_name}/config/routes.rb"
-    template 'initializer.rb.erb', "drivers/#{file_name}/config/initializers/#{file_name}_feature.rb"
-    template 'module.rb.erb',      "drivers/#{file_name}/app/models/#{file_name}.rb"
-    template 'README.md.erb',      "drivers/#{file_name}/README.md"
+    template 'routes.rb.erb',      "#{RailsDrivers.config.drivers_path}/#{file_name}/config/routes.rb"
+    template 'initializer.rb.erb', "#{RailsDrivers.config.drivers_path}/#{file_name}/config/initializers/#{file_name}_feature.rb"
+    template 'module.rb.erb',      "#{RailsDrivers.config.drivers_path}/#{file_name}/app/models/#{file_name}.rb"
+    template 'README.md.erb',      "#{RailsDrivers.config.drivers_path}/#{file_name}/README.md"
   end
 end

--- a/lib/rails_drivers.rb
+++ b/lib/rails_drivers.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 require 'rails_drivers/version'
+require 'rails_drivers/config'
 require 'rails_drivers/setup'
-require 'rails_drivers/railtie'
+require 'rails_drivers/railtie' if defined?(Rails)
 require 'rails_drivers/extensions'
 
 module RailsDrivers

--- a/lib/rails_drivers/config.rb
+++ b/lib/rails_drivers/config.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module RailsDrivers
+  class Config
+    DEFAULT_DRIVERS_PATH = 'drivers'
+
+    attr_accessor :drivers_path
+
+    def initialize(options = {})
+      @drivers_path = options[:drivers_path] || DEFAULT_DRIVERS_PATH
+    end
+  end
+
+  def self.config
+    @config ||= Config.new
+  end
+
+  def self.configure
+    yield config if block_given?
+  end
+end

--- a/lib/rails_drivers/extensions.rb
+++ b/lib/rails_drivers/extensions.rb
@@ -11,7 +11,7 @@ module RailsDrivers
 
       possible_extensions = Dir.glob(
         Rails.root.join(
-          'drivers', '*', 'extensions',
+          RailsDrivers.config.drivers_path.to_s, '*', 'extensions',
           "#{name.underscore}_extension.rb"
         )
       )
@@ -19,7 +19,7 @@ module RailsDrivers
       @@driver_extensions = possible_extensions.map do |path|
         require_dependency path
 
-        %r{drivers/(?<driver_name>[^/]+)/extensions} =~ path
+        %r{#{RailsDrivers.config.drivers_path}/(?<driver_name>[^/]+)/extensions} =~ path
 
         extension = "#{driver_name.classify}::#{name}Extension".constantize
         include extension

--- a/lib/rails_drivers/files.rb
+++ b/lib/rails_drivers/files.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative './config'
+
 module RailsDrivers
   module Files
     class Error < StandardError
@@ -9,10 +11,10 @@ module RailsDrivers
 
     def isolate(driver)
       raise Error, 'No driver specified' if driver.nil? || driver == ''
-      raise Error, "Driver #{driver.inspect} not found" unless File.exist?("drivers/#{driver}")
+      raise Error, "Driver #{driver.inspect} not found" unless File.exist?("#{RailsDrivers.config.drivers_path}/#{driver}")
 
       FileUtils.mkdir_p 'tmp/drivers'
-      Dir['drivers/*'].each do |driver_path|
+      Dir["#{RailsDrivers.config.drivers_path}/*"].each do |driver_path|
         next if driver_path.include?("/#{driver}")
 
         FileUtils.mv driver_path, "tmp/#{driver_path}"
@@ -21,7 +23,7 @@ module RailsDrivers
 
     def clear
       FileUtils.mkdir_p 'tmp/drivers'
-      Dir['drivers/*'].each do |driver_path|
+      Dir["#{RailsDrivers.config.drivers_path}/*"].each do |driver_path|
         FileUtils.mv driver_path, "tmp/#{driver_path}"
       end
     end
@@ -29,7 +31,7 @@ module RailsDrivers
     def restore
       Dir['tmp/drivers/*'].each do |tmp_driver_path|
         driver = tmp_driver_path.split('/').last
-        FileUtils.mv tmp_driver_path, "drivers/#{driver}"
+        FileUtils.mv tmp_driver_path, "#{RailsDrivers.config.drivers_path}/#{driver}"
       end
     end
   end

--- a/lib/rails_drivers/railtie.rb
+++ b/lib/rails_drivers/railtie.rb
@@ -8,8 +8,8 @@ module RailsDrivers
       load File.expand_path("#{__dir__}/../tasks/rails_drivers_tasks.rake")
 
       # load drivers rake tasks
-      Dir['drivers/*/lib/tasks/**/*.rake'].each do |driver_rake_file|
-        %r{^drivers/(?<driver_name>\w+)/} =~ driver_rake_file
+      Dir["#{RailsDrivers.config.drivers_path}/*/lib/tasks/**/*.rake"].each do |driver_rake_file|
+        %r{^#{RailsDrivers.config.drivers_path}/(?<driver_name>\w+)/} =~ driver_rake_file
 
         namespace(:driver) do
           namespace(driver_name) do
@@ -27,7 +27,7 @@ module RailsDrivers
     if Rails::VERSION::MAJOR >= 6
       initializer 'rails_drivers.autoloader.collapse' do
         Rails.autoloaders.each do |loader|
-          loader.collapse('drivers/*/extensions')
+          loader.collapse("#{RailsDrivers.config.drivers_path}/*/extensions")
         end
       end
     end

--- a/lib/rails_drivers/routes.rb
+++ b/lib/rails_drivers/routes.rb
@@ -5,7 +5,7 @@ module RailsDrivers
     def self.load_driver_routes
       return if defined?(REPLACE_DEFAULT_PATH_WITH_DRIVER)
 
-      Dir[Rails.root.join('drivers/*')].each do |path|
+      Dir[Rails.root.join("#{RailsDrivers.config.drivers_path}/*")].each do |path|
         load "#{path}/config/routes.rb" if File.exist?("#{path}/config/routes.rb")
       end
     end

--- a/lib/rails_drivers/setup.rb
+++ b/lib/rails_drivers/setup.rb
@@ -33,21 +33,29 @@ module RailsDrivers
       Rails.application.config
     end
 
+    def drivers_path
+      RailsDrivers.config.drivers_path
+    end
+
+    def add_rails_autoload_path(path)
+      rails_config.autoload_paths << path
+    end
+
     def replace_rails_paths_with_driver(driver_name)
-      rails_config.autoload_paths << "#{rails_config.root}/drivers"
+      add_rails_autoload_path "#{rails_config.root}/#{drivers_path}"
 
       DRIVER_PATHS.each do |path|
-        rails_config.paths[path] = "drivers/#{driver_name}/#{path}"
+        rails_config.paths[path] = "#{drivers_path}/#{driver_name}/#{path}"
         rails_config.autoload_paths += [
-          "#{rails_config.root}/drivers/#{driver_name}/lib"
+          "#{rails_config.root}/#{drivers_path}/#{driver_name}/lib"
         ]
       end
     end
 
     def add_every_driver_to_rails_paths
-      rails_config.autoload_paths << "#{rails_config.root}/drivers"
+      add_rails_autoload_path "#{rails_config.root}/#{drivers_path}"
 
-      Dir['drivers/*'].each do |driver|
+      Dir["#{drivers_path}/*"].each do |driver|
         DRIVER_PATHS.each do |path|
           rails_config.paths[path] << "#{driver}/#{path}"
         end

--- a/spec/bin/driver_spec.rb
+++ b/spec/bin/driver_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'bin/driver' do
     run_command('rails g driver driver_name')
     run_command('driver driver_name g migration create_tests value:integer')
 
-    migrations = Dir[File.expand_path(File.join(dummy_app, 'drivers/driver_name/db/migrate/*'))]
+    migrations = Dir[File.expand_path(File.join(dummy_app, "#{drivers_path}/driver_name/db/migrate/*"))]
     expect(migrations.size).to eq 1
     expect(migrations.first).to include 'create_tests'
   end
@@ -16,8 +16,8 @@ RSpec.describe 'bin/driver' do
     run_command('rails g driver one')
     run_command('rails g driver two')
 
-    expect(run_command 'ls -t drivers').to eq "two\none\n"
-    expect(run_command 'driver one do ls drivers').to eq "one\n"
-    expect(run_command 'ls -t drivers').to eq "two\none\n"
+    expect(run_command "ls -t #{drivers_path}").to eq "two\none\n"
+    expect(run_command "driver one do ls #{drivers_path}").to eq "one\n"
+    expect(run_command "ls -t #{drivers_path}").to eq "two\none\n"
   end
 end

--- a/spec/bin/nodriver_spec.rb
+++ b/spec/bin/nodriver_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe 'bin/nodriver' do
     run_command('rails g driver one')
     run_command('rails g driver two')
 
-    expect(run_command 'ls -t drivers').to eq "two\none\n"
-    expect(run_command 'nodriver do ls drivers').to be_empty
-    expect(run_command 'ls -t drivers').to eq "two\none\n"
+    expect(run_command "ls -t #{drivers_path}").to eq "two\none\n"
+    expect(run_command "nodriver do ls #{drivers_path}").to be_empty
+    expect(run_command "ls -t #{drivers_path}").to eq "two\none\n"
   end
 end

--- a/spec/drivers_spec.rb
+++ b/spec/drivers_spec.rb
@@ -103,17 +103,17 @@ RSpec.describe 'A Rails Driver' do
     end
   end
 
-  it_behaves_like 'an engine', 'app/models',               'app/models/concerns'
-  it_behaves_like 'an engine', 'drivers/store/app/models', 'drivers/store/app/models/concerns'
+  it_behaves_like 'an engine', 'app/models', 'app/models/concerns'
+  it_behaves_like 'an engine', "#{drivers_path}/store/app/models", "#{drivers_path}/store/app/models/concerns"
 
-  it_behaves_like 'an engine', 'app/controllers',               'app/controllers/concerns'
-  it_behaves_like 'an engine', 'drivers/store/app/controllers', 'drivers/store/app/controllers/concerns'
+  it_behaves_like 'an engine', 'app/controllers', 'app/controllers/concerns'
+  it_behaves_like 'an engine', "#{drivers_path}/store/app/controllers", "#{drivers_path}/store/app/controllers/concerns"
 
   context 'with a controller in a driver' do
     before do
-      create_file 'app/models/product.rb',                                product_model
-      create_file 'drivers/store/app/controllers/products_controller.rb', products_controller
-      create_file 'drivers/store/config/routes.rb',                       product_routes
+      create_file 'app/models/product.rb', product_model
+      create_file "#{drivers_path}/store/app/controllers/products_controller.rb", products_controller
+      create_file "#{drivers_path}/store/config/routes.rb",                       product_routes
     end
 
     it 'sets up routes' do
@@ -124,8 +124,8 @@ RSpec.describe 'A Rails Driver' do
     end
 
     it 'renders webpacker packs in drivers' do
-      create_file 'drivers/store/app/views/products/new.html.erb', products_new_view
-      create_file 'drivers/store/app/javascript/packs/products.js', products_pack
+      create_file "#{drivers_path}/store/app/views/products/new.html.erb", products_new_view
+      create_file "#{drivers_path}/store/app/javascript/packs/products.js", products_pack
       run_command 'bin/webpack'
 
       script_file = find_js_pack http(:get, '/products/new'), 'products'
@@ -135,9 +135,9 @@ RSpec.describe 'A Rails Driver' do
 
   context 'with a mailer in a driver' do
     before do
-      create_file 'drivers/something/app/mailers/test_mailer.rb', test_mailer
-      create_file 'drivers/something/app/views/test_mailer/some_message.html.erb', test_mailer_html
-      create_file 'drivers/something/app/views/test_mailer/some_message.text.erb', test_mailer_text
+      create_file "#{drivers_path}/something/app/mailers/test_mailer.rb", test_mailer
+      create_file "#{drivers_path}/something/app/views/test_mailer/some_message.html.erb", test_mailer_html
+      create_file "#{drivers_path}/something/app/views/test_mailer/some_message.text.erb", test_mailer_text
     end
 
     it 'can send mail properly' do
@@ -189,18 +189,18 @@ RSpec.describe 'A Rails Driver' do
     end
 
     before do
-      create_file 'drivers/store/app/models/product.rb',       product_model
-      create_file 'drivers/store/spec/models/product_spec.rb', product_model_spec
-      create_file 'drivers/store/spec/factories/product.rb',   product_factory
-      create_file 'spec/factories/funny_product.rb',           funny_product_factory
+      create_file "#{drivers_path}/store/app/models/product.rb",       product_model
+      create_file "#{drivers_path}/store/spec/models/product_spec.rb", product_model_spec
+      create_file "#{drivers_path}/store/spec/factories/product.rb",   product_factory
+      create_file 'spec/factories/funny_product.rb', funny_product_factory
     end
 
     it 'properly loads the factory' do
-      run_command 'rspec drivers/store/spec/models/product_spec.rb -t in_driver'
+      run_command "rspec #{drivers_path}/store/spec/models/product_spec.rb -t in_driver"
     end
 
     it 'still loads non-driver factories' do
-      run_command 'rspec drivers/store/spec/models/product_spec.rb -t not_in_driver'
+      run_command "rspec #{drivers_path}/store/spec/models/product_spec.rb -t not_in_driver"
     end
   end
 
@@ -217,8 +217,8 @@ RSpec.describe 'A Rails Driver' do
     end
 
     before do
-      create_file 'drivers/store/lib/tasks/dummy.rake', make_rake_task(:dummy)
-      create_file 'drivers/store/lib/tasks/nested/dummy.rake', make_rake_task(:dummy_nested)
+      create_file "#{drivers_path}/store/lib/tasks/dummy.rake", make_rake_task(:dummy)
+      create_file "#{drivers_path}/store/lib/tasks/nested/dummy.rake", make_rake_task(:dummy_nested)
     end
 
     it 'properly loads the rake tasks' do

--- a/spec/dummy_5.2/config/initializers/rails_drivers.rb
+++ b/spec/dummy_5.2/config/initializers/rails_drivers.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'rails_drivers'
+
+RailsDrivers.configure do |config|
+  config.drivers_path = ENV['DRIVERS_PATH']
+end

--- a/spec/dummy_5.2/config/webpack/environment.js
+++ b/spec/dummy_5.2/config/webpack/environment.js
@@ -23,7 +23,7 @@ const addToEntryObject = (sourcePath) => {
   })
 }
 
-sync('drivers/*').forEach((driverPath) => {
+sync(`${process.env.DRIVERS_PATH || 'drivers'}/*`).forEach((driverPath) => {
   addToEntryObject(join(driverPath, config.source_path));
 })
 //// End driver code ////

--- a/spec/dummy_5.2/spec/spec_helper.rb
+++ b/spec/dummy_5.2/spec/spec_helper.rb
@@ -7,6 +7,6 @@ require 'rspec/rails'
 RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
 
-  FactoryBot.definition_file_paths += Dir['drivers/*/spec/factories']
+  FactoryBot.definition_file_paths += Dir["#{RailsDrivers.config.drivers_path}/*/spec/factories"]
   FactoryBot.reload
 end

--- a/spec/dummy_6.0/config/initializers/rails_drivers.rb
+++ b/spec/dummy_6.0/config/initializers/rails_drivers.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'rails_drivers'
+
+RailsDrivers.configure do |config|
+  config.drivers_path = ENV['DRIVERS_PATH']
+end

--- a/spec/dummy_6.0/config/webpack/environment.js
+++ b/spec/dummy_6.0/config/webpack/environment.js
@@ -22,7 +22,7 @@ const addToEntryObject = (sourcePath) => {
   })
 }
 
-sync('drivers/*').forEach((driverPath) => {
+sync(`${process.env.DRIVERS_PATH || 'drivers'}/*`).forEach((driverPath) => {
   addToEntryObject(join(driverPath, config.source_path));
 })
 //// End driver code ////

--- a/spec/dummy_6.0/spec/spec_helper.rb
+++ b/spec/dummy_6.0/spec/spec_helper.rb
@@ -7,6 +7,6 @@ require 'rspec/rails'
 RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
 
-  FactoryBot.definition_file_paths += Dir['drivers/*/spec/factories']
+  FactoryBot.definition_file_paths += Dir["#{RailsDrivers.config.drivers_path}/*/spec/factories"]
   FactoryBot.reload
 end

--- a/spec/generators/driver_generator_spec.rb
+++ b/spec/generators/driver_generator_spec.rb
@@ -9,38 +9,38 @@ RSpec.describe 'rails g driver' do
 
   context 'creating files' do
     it 'creates the app directory' do
-      expect(dummy_app).to have_file 'drivers/driver_name/app/'
+      expect(dummy_app).to have_driver_file 'driver_name/app/'
     end
 
     it 'creates the models directory' do
-      expect(dummy_app).to have_file 'drivers/driver_name/app/models/driver_name/'
-      expect(dummy_app).to have_file 'drivers/driver_name/app/models/driver_name.rb'
+      expect(dummy_app).to have_driver_file 'driver_name/app/models/driver_name/'
+      expect(dummy_app).to have_driver_file 'driver_name/app/models/driver_name.rb'
     end
 
     it 'creates the controllers directory' do
-      expect(dummy_app).to have_file 'drivers/driver_name/app/controllers/'
-      expect(dummy_app).to have_file 'drivers/driver_name/app/controllers/driver_name/'
+      expect(dummy_app).to have_driver_file 'driver_name/app/controllers/'
+      expect(dummy_app).to have_driver_file 'driver_name/app/controllers/driver_name/'
     end
 
     it 'creates the views directory' do
-      expect(dummy_app).to have_file 'drivers/driver_name/app/views/'
-      expect(dummy_app).to have_file 'drivers/driver_name/app/views/driver_name/'
+      expect(dummy_app).to have_driver_file 'driver_name/app/views/'
+      expect(dummy_app).to have_driver_file 'driver_name/app/views/driver_name/'
     end
 
     it 'creates the routes' do
-      expect(dummy_app).to have_file 'drivers/driver_name/config/routes.rb'
+      expect(dummy_app).to have_driver_file 'driver_name/config/routes.rb'
     end
 
     it 'creates the driver initializer' do
-      expect(dummy_app).to have_file 'drivers/driver_name/config/initializers/driver_name_feature.rb'
+      expect(dummy_app).to have_driver_file 'driver_name/config/initializers/driver_name_feature.rb'
     end
 
     it 'creates the tasks directory' do
-      expect(dummy_app).to have_file 'drivers/driver_name/lib/tasks/.keep'
+      expect(dummy_app).to have_driver_file 'driver_name/lib/tasks/.keep'
     end
 
     it 'creates the readme' do
-      expect(dummy_app).to have_file 'drivers/driver_name/README.md'
+      expect(dummy_app).to have_driver_file 'driver_name/README.md'
     end
   end
 
@@ -58,13 +58,13 @@ RSpec.describe 'rails g driver' do
 
   context 'the routes.rb' do
     it 'draws from the Rails application' do
-      expect(read_file('drivers/driver_name/config/routes.rb')).to include "Dummy::Application.routes.draw do\n"
+      expect(read_file("#{drivers_path}/driver_name/config/routes.rb")).to include "Dummy::Application.routes.draw do\n"
     end
   end
 
   context 'the readme' do
     it 'includes the driver name' do
-      expect(read_file('drivers/driver_name/README.md')).to include 'DriverName'
+      expect(read_file("#{drivers_path}/driver_name/README.md")).to include 'DriverName'
     end
   end
 end

--- a/spec/overrides_spec.rb
+++ b/spec/overrides_spec.rb
@@ -102,8 +102,8 @@ RSpec.describe 'Rails Driver Extensions' do
         IO.write 'before.out', Product.new.respond_to?(:extension_method)
 
         # Write file mid-session
-        FileUtils.mkdir_p 'drivers/store/extensions'
-        FileUtils.cp 'tmp/product_extension.rb', 'drivers/store/extensions'
+        FileUtils.mkdir_p "#{drivers_path}/store/extensions"
+        FileUtils.cp 'tmp/product_extension.rb', "#{drivers_path}/store/extensions"
 
         # Reload and the plugin should show up
         reload!
@@ -122,7 +122,7 @@ RSpec.describe 'Rails Driver Extensions' do
 
   context 'with an extension present' do
     before do
-      create_file 'drivers/store/extensions/product_extension.rb', product_extension
+      create_file "#{drivers_path}/store/extensions/product_extension.rb", product_extension
     end
 
     it 'is included by the model' do
@@ -143,7 +143,7 @@ RSpec.describe 'Rails Driver Extensions' do
 
       script = %(
         IO.write 'before.out', Product.new.extension_method
-        FileUtils.cp 'tmp/new_product_extension.rb', 'drivers/store/extensions/product_extension.rb'
+        FileUtils.cp 'tmp/new_product_extension.rb', "#{drivers_path}/store/extensions/product_extension.rb"
         reload!
         IO.write 'after.out', Product.new.extension_method
       )
@@ -162,7 +162,7 @@ RSpec.describe 'Rails Driver Extensions' do
 
       script = %(
         IO.write 'before.out', Product.new.extension_method
-        FileUtils.cp 'tmp/new_product_extension.rb', 'drivers/store/extensions/product_extension.rb'
+        FileUtils.cp 'tmp/new_product_extension.rb', "#{drivers_path}/store/extensions/product_extension.rb"
         reload!
         begin
           Product.new.extension_method # This method should no longer be present!
@@ -184,8 +184,8 @@ RSpec.describe 'Rails Driver Extensions' do
 
   context 'with multiple extensions present' do
     before do
-      create_file 'drivers/store/extensions/product_extension.rb', product_extension
-      create_file 'drivers/admin/extensions/product_extension.rb', other_driver_product_extension
+      create_file "#{drivers_path}/store/extensions/product_extension.rb", product_extension
+      create_file "#{drivers_path}/admin/extensions/product_extension.rb", other_driver_product_extension
     end
 
     it 'includes both of them' do
@@ -199,7 +199,7 @@ RSpec.describe 'Rails Driver Extensions' do
 
   context 'when an extension shadows a method in the overridden class' do
     before do
-      create_file 'drivers/store/extensions/product_extension.rb', name_clash_product_extension
+      create_file "#{drivers_path}/store/extensions/product_extension.rb", name_clash_product_extension
     end
 
     it 'issues a warning' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,6 +28,7 @@ Dir["#{__dir__}/support/*.rb"].sort.each { |f| require f }
 
 RSpec.configure do |config|
   config.include DummyAppHelpers
+  config.include DriversPathHelpers
 
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest

--- a/spec/support/drivers_path_helpers.rb
+++ b/spec/support/drivers_path_helpers.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module DriversPathHelpers
+  def self.included(klass)
+    klass.send(:extend, DriversPathHelpers)
+
+    RSpec::Matchers.define :have_driver_file do |file_path|
+      match do |dummy_app_path|
+        File.exist? File.expand_path(File.join(dummy_app_path, drivers_path, file_path))
+      end
+    end
+  end
+
+  def drivers_path
+    ENV['DRIVERS_PATH'] || 'drivers'
+  end
+end

--- a/spec/tasks/rails_drivers_tasks_spec.rb
+++ b/spec/tasks/rails_drivers_tasks_spec.rb
@@ -13,9 +13,9 @@ RSpec.describe 'tasks/rails_drivers_tasks.rake' do
     context 'and a valid driver name is given' do
       it 'removes the other two drivers' do
         run_command 'rake driver:isolate[second]'
-        expect(dummy_app).to_not have_file 'drivers/first'
-        expect(dummy_app).to     have_file 'drivers/second'
-        expect(dummy_app).to_not have_file 'drivers/third'
+        expect(dummy_app).to_not have_driver_file '/first'
+        expect(dummy_app).to     have_driver_file '/second'
+        expect(dummy_app).to_not have_driver_file '/third'
       end
     end
 
@@ -35,9 +35,9 @@ RSpec.describe 'tasks/rails_drivers_tasks.rake' do
   describe 'rake driver:clear' do
     it 'removes all drivers' do
       run_command 'rake driver:clear'
-      expect(dummy_app).to_not have_file 'drivers/first'
-      expect(dummy_app).to_not have_file 'drivers/second'
-      expect(dummy_app).to_not have_file 'drivers/third'
+      expect(dummy_app).to_not have_driver_file '/first'
+      expect(dummy_app).to_not have_driver_file '/second'
+      expect(dummy_app).to_not have_driver_file '/third'
     end
   end
 
@@ -45,9 +45,9 @@ RSpec.describe 'tasks/rails_drivers_tasks.rake' do
     it 'undoes the effects of driver:isolate' do
       run_command 'rake driver:isolate[second]'
       run_command 'rake driver:restore'
-      expect(dummy_app).to have_file 'drivers/first'
-      expect(dummy_app).to have_file 'drivers/second'
-      expect(dummy_app).to have_file 'drivers/third'
+      expect(dummy_app).to have_driver_file '/first'
+      expect(dummy_app).to have_driver_file '/second'
+      expect(dummy_app).to have_driver_file '/third'
     end
   end
 end


### PR DESCRIPTION
Allow for configuration of custom directories for drivers.  The drivers directory can now be configured via:

```ruby
RailsDrivers.configure do |config|
  config.drivers_path = 'my_custom_drivers_path'
end
```

## Changelog
- added `RailsDrivers::Config`
- added `RailsDrivers.config`
- added `RailsDrivers.configure`
- changed RailsDrivers can now be configured to be stored in a custom directory