### PR TITLE
Support Ruby 3.0

### DIFF
--- a/.github/workflows/gempush.yml
+++ b/.github/workflows/gempush.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@master
-    - name: Set up Ruby 2.6
+    - name: Set up Ruby 3.0
       uses: actions/setup-ruby@v1
       with:
-        version: 2.6.x
+        version: '3.0'
 
     - name: Publish to RubyGems
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,12 +25,12 @@ jobs:
     strategy:
       matrix:
         versions:
-          - rails: '5.2',
-            ruby: '2.7'
-          - rails: '6.0',
-            ruby: '2.7'
-          - rails: '6.0',
-            ruby: '3.0'
+        - rails: '5.2'
+          ruby: '2.7'
+        - rails: '6.0'
+          ruby: '2.7'
+        - rails: '6.0'
+          ruby: '3.0'
     steps:
       - uses: actions/checkout@v1
       - name: Set up Ruby ${{ matrix.versions.ruby }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - name: Set up Ruby 2.5
+      - name: Set up Ruby 3.0
         uses: actions/setup-ruby@v1
         with:
-          ruby-version: 2.5.x
+          ruby-version: '3.0'
       - name: Install sqlite3
         run: sudo apt-get install -y libsqlite3-dev
       - name: Build
@@ -24,23 +24,29 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rails: ['5.2', '6.0']
+        versions:
+          - rails: '5.2',
+            ruby: '2.7'
+          - rails: '6.0',
+            ruby: '2.7'
+          - rails: '6.0',
+            ruby: '3.0'
     steps:
       - uses: actions/checkout@v1
-      - name: Set up Ruby 2.5
+      - name: Set up Ruby ${{ matrix.versions.ruby }}
         uses: actions/setup-ruby@v1
         with:
-          ruby-version: 2.5.x
+          ruby-version: ${{ matrix.versions.ruby }}
       - name: Install sqlite3
         run: sudo apt-get install -y libsqlite3-dev
       - name: Install nodejs dependencies
         run: |
-          cd spec/dummy_${{ matrix.rails }}
+          cd spec/dummy_${{ matrix.versions.rails }}
           npm install
       - name: Build
         run: |
-          export RAILS_VERSION=${{ matrix.rails }}
+          export RAILS_VERSION=${{ matrix.versions.rails }}
           gem install bundler
           bundle install --jobs 4 --retry 3
       - name: RSpec
-        run: RAILS_VERSION=${{ matrix.rails }} bundle exec rspec
+        run: RAILS_VERSION=${{ matrix.versions.rails }} bundle exec rspec

--- a/lib/rails_drivers/extensions.rb
+++ b/lib/rails_drivers/extensions.rb
@@ -32,7 +32,8 @@ module RailsDrivers
             next unless extension.instance_methods.include?(method_name)
 
             Rails.logger.warn "Driver extension method #{extension.name}##{method_name} "\
-              "is shadowed by #{name}##{method_name} and will likely not do anything."
+                              "is shadowed by #{name}##{method_name} and will likely "\
+                              'not do anything.'
           end
 
           super(method_name)

--- a/lib/rails_drivers/files.rb
+++ b/lib/rails_drivers/files.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'fileutils'
+
 module RailsDrivers
   module Files
     class Error < StandardError

--- a/rails_drivers.gemspec
+++ b/rails_drivers.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables << 'driver'
   spec.executables << 'nodriver'
 
-  spec.required_ruby_version = '~> 2' # rubocop:disable Gemspec/RequiredRubyVersion
+  spec.required_ruby_version = '>= 2.5' # rubocop:disable Gemspec/RequiredRubyVersion
 
   rails = case ENV['RAILS_VERSION']
           when '5.2'

--- a/spec/extensions_spec.rb
+++ b/spec/extensions_spec.rb
@@ -201,7 +201,7 @@ RSpec.describe 'Rails Driver Extensions' do
       output = run_command 'rails c', input: 'Product', capture_stderr: true
 
       expect(output).to include 'Driver extension method Store::ProductExtension#say_hello '\
-        'is shadowed by Product#say_hello and will likely not do anything.'
+                                'is shadowed by Product#say_hello and will likely not do anything.'
     end
   end
 end

--- a/spec/overrides_spec.rb
+++ b/spec/overrides_spec.rb
@@ -133,11 +133,6 @@ RSpec.describe 'Rails Driver Extensions' do
       expect(extension_method_output).to eq "it worked!\n"
     end
 
-    it "populates the model's driver_extensions" do
-      extensions = run_ruby %(puts Product.driver_extensions.to_s)
-      expect(extensions).to eq "[Store::ProductExtension]\n"
-    end
-
     it 'persists across reloads' do
       create_file 'tmp/new_product_extension.rb', alt_product_extension
 

--- a/spec/support/dummy_app_helpers.rb
+++ b/spec/support/dummy_app_helpers.rb
@@ -102,7 +102,7 @@ module DummyAppHelpers
     random_string = SecureRandom.hex.chars.first(4).join
     @dummy_app = File.expand_path File.join(__dir__, "../dummy-#{random_string}")
     FileUtils.rm_r @dummy_app if File.exist?(@dummy_app)
-    FileUtils.cp_r dummy_app_template, @dummy_app
+    cp_r dummy_app_template, @dummy_app
   end
 
   def teardown_dummy_app
@@ -117,6 +117,10 @@ module DummyAppHelpers
   #
 
   private
+
+  def cp_r(src, dst)
+    system "cp -r --reflink #{src} #{dst}"
+  end
 
   def truncate_lines(stream, limit: 200)
     lines = []

--- a/spec/support/dummy_app_helpers.rb
+++ b/spec/support/dummy_app_helpers.rb
@@ -119,7 +119,7 @@ module DummyAppHelpers
   private
 
   def cp_r(src, dst)
-    system "cp -r --reflink=always #{src} #{dst}"
+    system "cp -r --reflink=auto #{src} #{dst}"
   end
 
   def truncate_lines(stream, limit: 200)

--- a/spec/support/dummy_app_helpers.rb
+++ b/spec/support/dummy_app_helpers.rb
@@ -119,7 +119,7 @@ module DummyAppHelpers
   private
 
   def cp_r(src, dst)
-    system "cp -r --reflink #{src} #{dst}"
+    system "cp -r --reflink=always #{src} #{dst}"
   end
 
   def truncate_lines(stream, limit: 200)


### PR DESCRIPTION
This is the only change we need to account for: https://rubyreferences.github.io/rubychanges/3.0.html#changes-in-class-variable-behavior

CI will now test Rails 5 on Ruby 2.7. Rails 6 is tested on Ruby 2.7 and 3.0.
